### PR TITLE
fix: syncing new posts

### DIFF
--- a/src/post/mod.rs
+++ b/src/post/mod.rs
@@ -40,7 +40,7 @@ pub fn filter_unsynced_posts(
 
         match post_updated {
             Some(post_updated) => post_updated < updated,
-            None => false,
+            None => true,
         }
     });
     Ok(posts)


### PR DESCRIPTION
当 post 在数据库中不存在时, 返回 `true` 确保能被同步